### PR TITLE
Feature/calculate player resupply_downtime, other_downtime

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,21 @@
+
+{
+  "arrowParens": "avoid",
+  "bracketSpacing": true,
+  "endOfLine": "auto",
+  "htmlWhitespaceSensitivity": "css",
+  "insertPragma": false,
+  "jsxBracketSameLine": false,
+  "jsxSingleQuote": false,
+  "printWidth": 80,
+  "proseWrap": "preserve",
+  "quoteProps": "as-needed",
+  "requirePragma": false,
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "useTabs": false,
+  "vueIndentScriptAndStyle": false,
+  "parser": "babel"
+}

--- a/index.js
+++ b/index.js
@@ -1068,7 +1068,7 @@ exports.handler = async (event, context) => {
             // if the player was deactivated again before they came up (e.g. reset, nuke), then this will be 0
             const uptimeDuration = Math.max(deacTimeDiff - 8000, 0);
 
-            if ([resuppliedActionCodes].includes(deac.type)) {
+            if ([...resuppliedActionCodes].includes(deac.type)) {
               // this was a resupply deactivation
               resupplyDowntime += deacDuration;
             } else {
@@ -1081,8 +1081,9 @@ exports.handler = async (event, context) => {
           });
 
           // add uptime from the final deac up to the player survived/eliminated time
-          // Note: if a player has no deacs, this line will crash when trying to process undefined.time
-          uptime += player.end - deacs[deacs.length - 1].time;
+          let lastDeac = deacs[deacs.length - 1];
+          uptime +=
+            player.end - (lastDeac && lastDeac.time ? lastDeac.time : 0);
 
           await client.query(sql`
                 UPDATE scorecards


### PR DESCRIPTION
Extends on calculating uptime to also calculate resupply_downtime and other_downtime.

Note that **game_length** should equal **uptime** + **resupply_downtime** + **other_downtime**

Also added prettierrc config file that should match your local default settings.